### PR TITLE
ASM-4189 Compellent puppet configuration broken due to recent EM disc…

### DIFF
--- a/lib/puppet/compellent/transport.rb
+++ b/lib/puppet/compellent/transport.rb
@@ -30,7 +30,7 @@ module Puppet
           self.host = parsed_config[:host]
           self.password = parsed_config[:password]
           self.port = parsed_config[:port]
-          parsed_config[:port] == 443 ? self.discovery_type = 'Storage_Center' : self.discovery_type = 'EM'
+          parsed_config[:discovery_type] != 'EM' ? self.discovery_type = 'Storage_Center' : self.discovery_type = 'EM'
         end
 
         Puppet.debug('Device login started')


### PR DESCRIPTION
…overy

Now discovery type is default to Storage center. If discovery_type parameter is passed with value as 'EM' then only the transport for EM will be created