### PR TITLE
ASM-4325 EM Discovery is failing with Invalid URI error when domain name is passed as an input

### DIFF
--- a/lib/puppet/compellent/transport.rb
+++ b/lib/puppet/compellent/transport.rb
@@ -112,7 +112,7 @@ module Puppet
       end
 
       def get_jsession_id
-        login_base_url="https://#{self.user}:#{CGI.escape(self.password)}@#{self.host}:#{self.port}/api/rest"
+        login_base_url="https://#{CGI.escape(self.user)}:#{CGI.escape(self.password)}@#{self.host}:#{self.port}/api/rest"
         url = "#{login_base_url}/ApiConnection/Login"
 
         response = RestClient::Request.execute(:url => url,


### PR DESCRIPTION
CGI Escape was missing for the username. In case the username is having domain name then username passed in the URL was http://domainname\\username@password:URL leading the invalid URI error.

Added CGI escape for the username before pass the the URL for REST endpoint invocation