### PR TITLE
ASM-4325 EM Discovery is failing with Invalid URI error when domain name is passed as an input

### DIFF
--- a/lib/puppet/compellent/transport.rb
+++ b/lib/puppet/compellent/transport.rb
@@ -112,7 +112,12 @@ module Puppet
       end
 
       def get_jsession_id
-        login_base_url="https://#{CGI.escape(self.user)}:#{CGI.escape(self.password)}@#{self.host}:#{self.port}/api/rest"
+        # For EM we need a single backslash as we are passing the value in HTTP URL instead of commandline
+        # username and password are already CGI escaped in the upper layer
+        username = CGI.unescape(self.user)
+        username = username.gsub('\\\\','\\')
+        login_base_url="https://#{CGI.escape(username)}:#{CGI.escape(self.password)}@#{self.host}:#{self.port}/api/rest"
+
         url = "#{login_base_url}/ApiConnection/Login"
 
         response = RestClient::Request.execute(:url => url,


### PR DESCRIPTION

ASM Core is passing the username in form of 'domain\\username' but for EM API we need it in form of 'domain\username'. Updated the username before passing it to the REST endpoint for authentication cookie generation