### PR TITLE
ASM-4419 Compellent volume creation fails due to incorrect storage profile name

### DIFF
--- a/manifests/createvol.pp
+++ b/manifests/createvol.pp
@@ -27,7 +27,7 @@ define compellent::createvol (
   $volume_notes = '',
   $server_notes = '',
   $replayprofile = 'Sample',
-  $storageprofile = 'Low Priority',
+  $storageprofile = '',
   $servername = '',
   $operatingsystem = 'VMWare ESX 5.1',
   $serverfolder = '',


### PR DESCRIPTION
Storage profile name "Low Priority" is not supported by SCv2000. Resulting the volume creation when the value of storage profile is not passed and default value is picked from the manifest file
Removed the default value. In absence of the value, volume is created by default with Storage profile High Priority