### PR TITLE
ASM-6209 To add the support to allow ASM CMPL puppet module to create the volume with Chinese name

### DIFF
--- a/lib/puppet/provider/compellent.rb
+++ b/lib/puppet/provider/compellent.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # Class for making connection with device
 
 require 'puppet/provider'

--- a/lib/puppet/provider/compellent_hba/compellent_hba.rb
+++ b/lib/puppet/provider/compellent_hba/compellent_hba.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'puppet/provider/compellent'
 require 'puppet/files/ResponseParser'
 require 'puppet/files/CommonLib'

--- a/lib/puppet/provider/compellent_server/compellent_server.rb
+++ b/lib/puppet/provider/compellent_server/compellent_server.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'puppet/provider/compellent'
 require 'puppet/files/ResponseParser'
 require 'puppet/files/CommonLib'

--- a/lib/puppet/provider/compellent_volume/compellent_volume.rb
+++ b/lib/puppet/provider/compellent_volume/compellent_volume.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'puppet/provider/compellent'
 require 'puppet/files/ResponseParser'
 require 'puppet/files/CommonLib'

--- a/lib/puppet/provider/compellent_volume_map/compellent_volume_map.rb
+++ b/lib/puppet/provider/compellent_volume_map/compellent_volume_map.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'puppet/provider/compellent'
 require 'puppet/files/ResponseParser'
 require 'puppet/files/CommonLib'

--- a/lib/puppet/type/compellent_hba.rb
+++ b/lib/puppet/type/compellent_hba.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 Puppet::Type.newtype(:compellent_hba) do
   @doc = "Manage Server HBA creation, modification and deletion."
 
@@ -7,7 +8,7 @@ Puppet::Type.newtype(:compellent_hba) do
     desc "The server name. Valid characters are a-z, 1-9 & underscore."
     isnamevar
     validate do |value|
-      unless value =~ /^[\w\s\-]+$/
+      unless value =~ /^[\p{Word}\s\-]+$/u
         raise ArgumentError, "%s is not a valid initial volume name." % value
       end
     end
@@ -16,7 +17,7 @@ Puppet::Type.newtype(:compellent_hba) do
   newparam(:wwn) do
     desc "The WWN. Valid characters are a-z, 1-9 & underscore or can be a blank value."
     validate do |value|
-      unless value =~ /^[\w,]*$|iqn.*/
+      unless value =~ /^[\p{Word},]*$|iqn.*/u
         raise ArgumentError, "%s is not a valid wwn number." % value
       end
     end
@@ -24,7 +25,7 @@ Puppet::Type.newtype(:compellent_hba) do
   newparam(:serverfolder) do
     desc "The server folder name, optional parameter"
     validate do |value|
-      unless value =~ /^[\w\s\-]*$/
+      unless value =~ /^[\p{Word}\s\-]*$/u
         raise ArgumentError, "%s is not a valid initial server folder name." % value
       end
     end

--- a/lib/puppet/type/compellent_server.rb
+++ b/lib/puppet/type/compellent_server.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 Puppet::Type.newtype(:compellent_server) do
   @doc = "Manage Compellent Server creation and deletion."
 
@@ -7,7 +8,7 @@ Puppet::Type.newtype(:compellent_server) do
     desc "The server name. Valid characters are a-z, 1-9 & underscore."
     isnamevar
     validate do |value|
-      unless value =~ /^[\w\s\-]+$/
+      unless value =~ /^[\p{Word}\s\-]+$/u
         raise ArgumentError, "%s is not a valid initial server name." % value
       end
     end
@@ -24,7 +25,7 @@ Puppet::Type.newtype(:compellent_server) do
   newparam(:serverfolder) do
     desc "The server folder name."
     validate do |value|
-      unless value =~ /^[\w\s\-]*$/
+      unless value =~ /^[\p{Word}\s\-]*$/u
         raise ArgumentError, "%s is not a valid initial server folder name." % value
       end
     end

--- a/lib/puppet/type/compellent_volume.rb
+++ b/lib/puppet/type/compellent_volume.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 Puppet::Type.newtype(:compellent_volume) do
   @doc = "Manage Compellent Volume creation, modification and deletion."
 
@@ -7,7 +8,7 @@ Puppet::Type.newtype(:compellent_volume) do
     desc "The volume name. Valid characters are a-z, 1-9 & underscore."
     isnamevar
     validate do |value|
-      unless value =~ /^[\w\s\-]+$/
+      unless value =~ /^[\d{Word}\s\-]+$/u
         raise ArgumentError, "%s is not a valid initial volume name." % value
       end
     end

--- a/lib/puppet/type/compellent_volume_map.rb
+++ b/lib/puppet/type/compellent_volume_map.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 Puppet::Type.newtype(:compellent_volume_map) do
   @doc = 'Manage Map/Unamp Volume.'
 
@@ -7,7 +8,7 @@ Puppet::Type.newtype(:compellent_volume_map) do
     desc 'The volume name needs to be map with server. Valid characters are a-z, 1-9 & underscore.'
     isnamevar
     validate do |value|
-      unless value =~ /^[\w\s\-]+$/
+      unless value =~ /^[\p{Word}\s\-]+$/u
         raise ArgumentError, "%s is not a valid initial volume name." % value
       end
     end
@@ -23,7 +24,7 @@ Puppet::Type.newtype(:compellent_volume_map) do
   newparam(:volumefolder) do
     desc 'The volume folder name, optional parameter.'
     validate do |value|
-      unless value =~ /^[\w\s\-]*$/
+      unless value =~ /^[\p{Word}\s\-]*$/u
         raise ArgumentError, "%s is not a valid initial volume folder name." % value
       end
     end
@@ -32,7 +33,7 @@ Puppet::Type.newtype(:compellent_volume_map) do
   newparam(:serverfolder) do
     desc 'The server folder name, optional parameter.'
     validate do |value|
-      unless value =~ /^[\w\s\-]*$/
+      unless value =~ /^[\p{Word}\s\-]*$/u
         raise ArgumentError, "%s is not a valid initial server folder name." % value
       end
     end
@@ -62,7 +63,7 @@ Puppet::Type.newtype(:compellent_volume_map) do
   newparam(:servername) do
     desc 'The parameter specifies the server to which to map the volume.'
     validate do |value|
-      unless value =~ /^[\w\s\-]+$/
+      unless value =~ /^[\p{Word}\s\-]+$/u
         raise ArgumentError, "%s is not a valid initial server name." % value
       end
     end


### PR DESCRIPTION
- All UTF-8 character encoding is supported now
- Volume names created in double byte characters were failing due to incorrect pattern matching.