### PR TITLE
ASM-6521, ASM-6522 Make discovery scripts recognize credential_id

### DIFF
--- a/bin/compellent_facts.rb
+++ b/bin/compellent_facts.rb
@@ -18,6 +18,7 @@ opts = Trollop::options do
   opt :timeout, 'command timeout', :default => 180
   opt :scheme, 'connection scheme', :default => 'https'
   opt :output, 'Output facts to file location', :type => :string, :required => true
+  opt :credential_id, 'dummy value for ASM, not used'
 end
 
 @file_path = File.join(Pathname.new(__FILE__).parent.parent,'lib','files')

--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -16,6 +16,7 @@ opts = Trollop::options do
   opt :community_string, 'community string' #This is a stub and shouldnt be used
   opt :discovery_type, 'Discovery type Storage_Center / EM', :default => 'Storage_Center'
   opt :output, 'Output facts to file location', :type => :string, :required => true
+  opt :credential_id, 'dummy value for ASM, not used'
 end
 response = ''
 opts[:port] == 443 ? discovery_type = 'Storage_Center' : discovery_type = 'EM'

--- a/bin/em_facts.rb
+++ b/bin/em_facts.rb
@@ -19,6 +19,7 @@ opts = Trollop::options do
   opt :scheme, 'connection scheme', :default => 'https'
   opt :discovery_type, 'Discovery type Storage_Center / EM', :default => 'EM'
   opt :output, 'Output facts to file location', :type => :string, :required => true
+  opt :credential_id, 'dummy value for ASM, not used'
 end
 
 @file_path = File.join(Pathname.new(__FILE__).parent.parent,'lib','files')


### PR DESCRIPTION
To support server and chassis discovery scripts to accept credential_id as parameter, ASM deployer's run_script will pass credential_id as command line arguments to any discovery scripts (similar to passing other generic arguments like username,password,output,community)string).

This means Trollop of the discovery scripts needs to declare accepting credential_id param, even if it is no-op.