### PR TITLE
ASM-7726 Compellent Discovery Failure with FW 6.7.11

### DIFF
--- a/lib/puppet/compellent/transport.rb
+++ b/lib/puppet/compellent/transport.rb
@@ -77,7 +77,7 @@ module Puppet
         if ENV["JAVA_HOME"]
           File.join(ENV["JAVA_HOME"], "/bin/java")
         else
-          "/opt/puppet/bin/java"
+          "/opt/java/bin/java"
         end
       end
 


### PR DESCRIPTION
JAVA HOME environment variable is not set for pe-puppet user. As a result discovery script was not able to invoke the CompCU with correct JAVA version. Now default JAVA path is set to /opt/java/ so that updated ASM appliance JAVA installation is used for CompCU JAR execution