### PR TITLE
ASM-8019 ASM Support for Compellent Enterprise Manager 2016 R2

### DIFF
--- a/lib/puppet/compellent/transport.rb
+++ b/lib/puppet/compellent/transport.rb
@@ -43,7 +43,6 @@ module Puppet
           raise ArgumentError, 'no password specified' unless self.password
 
           if self.jsessionid = get_jsession_id(em_login)
-            self.api_version = JSON.parse(em_login)["apiVersion"]
             Puppet.debug('Connection successful with EM') if !script_run
           else
             raise Puppet::Error, "Failed to get JSESSION ID from EM" if !script_run


### PR DESCRIPTION
Format of JSESSION Id that needs to be passed in the REST API header for authentication has changed with 2016 R2. Now we need to munge the content of set-cookie attribute before passing it to subseqent APIs.
Also API version value needs to be passed as "3.1" instead of "2.0"